### PR TITLE
fix: shows commits authored older than last 90 days

### DIFF
--- a/GitHub/github_contributor_count.py
+++ b/GitHub/github_contributor_count.py
@@ -25,19 +25,22 @@ for repo in organization.get_repos():
 
     # Get commits for the repository
     try:
+        # The GitHub API's since parameter only filters commits by their author date (the date the commit was authored) and not the pushed date. 
+        # If a commit was authored before 90 days but pushed recently, it will still be included in the results.
         commits = repo.get_commits(since=ninety_days_ago)
         for commit in commits:
             if commit.author is not None:  # Only consider commits with an associated GitHub user
                 username = commit.author.login
                 commit_date = commit.commit.author.date
-
-                # Store the most recent commit for each contributor
-                if username not in contributors or commit_date > contributors[username]['date']:
-                    contributors[username] = {
-                        'date': commit_date,
-                        'sha': commit.sha,
-                        'repo': repo.full_name
-                    }
+                # Additional filter to include only commits authored 90 days ago
+                if commit_date >= ninety_days_ago: 
+                    # Store the most recent commit for each contributor
+                    if username not in contributors or commit_date > contributors[username]['date']:
+                        contributors[username] = {
+                            'date': commit_date,
+                            'sha': commit.sha,
+                            'repo': repo.full_name
+                        }
     except GithubException as e:
         print(f"Error processing commits for repository {repo.full_name}: {e}")
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,15 @@
 
 - Counts the number of contributing developers within the last 90 days of a given GitHub Organization
 - Prints the name of each GitHub user, along with a link to a commit they've given in the last 90 days
-- A GitHub PAT is required for authentication. The permissions needed are shown below, and we recommend to use fine-grained tokens:
-<img width="895" alt="image" src="https://github.com/user-attachments/assets/7803c2f0-1631-45c3-9f61-8984ab11cc8f">
+- A GitHub PAT is required for authentication. The permissions needed are shown below, and we recommend to use fine-grained tokens
+    - Organization Permissions
+        - Members: Read-only
+    - Repository Permissions
+        - Metadata: Read-only
+        - Contents: Read-only
+        - Commits: Read-only
+    - Acoount Permissions
+        - Email addresses: Read-only
 
 ### Running the script:
 


### PR DESCRIPTION
The GitHub API's since parameter only filters commits by their author date (the date the commit was authored) and not the pushed date. If a commit was authored before 90 days but pushed recently, it will still be included in the results.

Hence including an additional check/filter to include only commits authored 90 days ago.