### PR TITLE
Mb improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,27 @@
+# Virtual environments
 .venv/
 venv/
 .venv
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+dist/
+build/
+
+# Environment / secrets
+.env
+.env.*
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/GitHub/github_contributors_90d.py
+++ b/GitHub/github_contributors_90d.py
@@ -2,291 +2,499 @@
 """
 GitHub Contributors Count Tool
 
-Purpose:
-  Calculates the number of unique contributing developers in a GitHub organization
-  over the last 90 days.
-
-Requirements:
-  Python 3.6+
-  Dependencies: requests, click
-
-Installation:
-  pip install -r requirements.txt
+Calculates the number of unique contributing developers in a GitHub
+organization over the last 90 days.
 
 Usage:
-  # Public org, no token (subject to lower rate limits)
-  python github_contributors_90d.py --org my-org
-
-  # Private org or higher rate limits (recommended)
   export GITHUB_TOKEN=ghp_...
   python github_contributors_90d.py --org my-org
-
-  # JSON output
   python github_contributors_90d.py --org my-org --format json
 
-Token Scopes:
-  - Public orgs: No scopes needed (or just public_repo).
-  - Private orgs: `read:org` and `repo` (read-only) scopes.
+Token permissions (fine-grained):
+  Repository  -> Metadata: Read-only, Contents: Read-only
+  Organization -> Members: Read-only
 """
 
 import os
+import re
 import sys
 import json
-import datetime
 import time
-from typing import Optional, Dict, Any, Set, Generator, List
+import datetime
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Optional, Dict, Any, Set, List, Tuple, Generator
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 import click
 
+# ---------------------------------------------------------------------------
 # Constants
+# ---------------------------------------------------------------------------
 DEFAULT_BASE_URL = "https://api.github.com"
 ENV_VAR_TOKEN = "GITHUB_TOKEN"
+REQUEST_TIMEOUT: Tuple[int, int] = (10, 30)  # (connect, read) seconds
+DEFAULT_WORKERS = 4
+PER_PAGE = 100
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sanitize(text: str, max_len: int = 300) -> str:
+    """Truncate and strip embedded credentials from error text."""
+    if not text:
+        return "Unknown error"
+    text = re.sub(r"://[^@/]+@", "://***@", text)
+    return text[:max_len]
+
+
+def _elapsed(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    return f"{m}m {s}s" if m else f"{s}s"
+
+
+def _summary_box(title: str, rows: List[Tuple[str, str]],
+                 result_label: str, result_value: str) -> None:
+    """Print a consistently-formatted summary table."""
+    w = 48
+    click.echo()
+    click.echo("=" * w)
+    click.echo(f"  {title}")
+    click.echo("=" * w)
+    for label, value in rows:
+        click.echo(f"  {label:<26}{value}")
+    click.echo("-" * w)
+    click.echo(f"  {result_label:<26}{result_value}")
+    click.echo("=" * w)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class ApiError(Exception):
+    """Non-success response from the GitHub API."""
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        super().__init__(f"HTTP {status_code}: {_sanitize(message)}")
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
 
 class GitHubClient:
-    def __init__(self, token: Optional[str], base_url: str = DEFAULT_BASE_URL):
-        self.token = token
-        self.base_url = base_url.rstrip('/')
-        self.session = requests.Session()
-        if self.token:
-            self.session.headers.update({"Authorization": f"token {self.token}"})
-        self.session.headers.update({"Accept": "application/vnd.github.v3+json"})
+    """Thread-safe GitHub REST API client with retry and rate-limit support."""
 
-    def _request(self, method: str, endpoint: str, params: Dict = None) -> Any:
-        url = f"{self.base_url}{endpoint}"
+    def __init__(self, token: Optional[str],
+                 base_url: str = DEFAULT_BASE_URL) -> None:
+        self._token = token
+        self._base_url = base_url.rstrip("/")
+        self._local = threading.local()
+        self._print_lock = threading.Lock()
+
+    def __repr__(self) -> str:
+        return (f"GitHubClient(base_url={self._base_url!r}, "
+                f"authenticated={self._token is not None})")
+
+    # -- Thread-local session ------------------------------------------------
+
+    @property
+    def _session(self) -> requests.Session:
+        """One connection-pooled session per thread."""
+        if not hasattr(self._local, "session"):
+            s = requests.Session()
+            if self._token:
+                s.headers["Authorization"] = f"token {self._token}"
+            s.headers["Accept"] = "application/vnd.github.v3+json"
+            s.headers["User-Agent"] = "contributors-count/1.0"
+
+            retry = Retry(
+                total=3,
+                backoff_factor=1,
+                status_forcelist=[500, 502, 503, 504],
+                allowed_methods=["GET"],
+                raise_on_status=False,
+            )
+            adapter = HTTPAdapter(
+                max_retries=retry, pool_connections=10, pool_maxsize=10,
+            )
+            s.mount("https://", adapter)
+            s.mount("http://", adapter)
+            self._local.session = s
+        return self._local.session
+
+    # -- Core request --------------------------------------------------------
+
+    def _get(self, url: str,
+             params: Optional[Dict[str, Any]] = None) -> requests.Response:
         while True:
-            response = self.session.request(method, url, params=params)
-            
-            # Handle Rate Limiting
-            if response.status_code == 403 and 'X-RateLimit-Remaining' in response.headers:
-                remaining = int(response.headers.get('X-RateLimit-Remaining', 0))
-                if remaining == 0:
-                    reset_time = int(response.headers.get('X-RateLimit-Reset', 0))
-                    sleep_seconds = max(0, reset_time - int(time.time())) + 1
-                    click.echo(f"Rate limit exceeded. Sleeping for {sleep_seconds} seconds...", err=True)
-                    time.sleep(sleep_seconds)
+            try:
+                resp = self._session.get(
+                    url, params=params, timeout=REQUEST_TIMEOUT,
+                )
+            except requests.ConnectionError:
+                raise ApiError(
+                    0, "Connection failed. Check network and --base-url.",
+                )
+            except requests.Timeout:
+                raise ApiError(
+                    0, f"Request timed out after {REQUEST_TIMEOUT[1]}s.",
+                )
+
+            # GitHub primary rate limit: 403 + remaining == 0
+            if resp.status_code == 403:
+                remaining = resp.headers.get("X-RateLimit-Remaining")
+                if remaining is not None and int(remaining) == 0:
+                    reset_ts = int(resp.headers.get("X-RateLimit-Reset", 0))
+                    wait = max(1, reset_ts - int(time.time()) + 1)
+                    with self._print_lock:
+                        click.echo(
+                            f"  Rate limit hit. Waiting {wait}s ...",
+                            err=True,
+                        )
+                    time.sleep(wait)
                     continue
 
-            if response.status_code != 200:
-                # Try to get error message
+            # Secondary / standard 429
+            if resp.status_code == 429:
+                retry_after = int(resp.headers.get("Retry-After", 60))
+                with self._print_lock:
+                    click.echo(
+                        f"  Rate limit hit. Waiting {retry_after}s ...",
+                        err=True,
+                    )
+                time.sleep(retry_after)
+                continue
+
+            if resp.status_code != 200:
                 try:
-                    data = response.json()
-                    message = data.get('message', response.text)
-                except:
-                    message = response.text
-                raise Exception(f"GitHub API Error ({response.status_code}): {message}")
+                    msg = resp.json().get("message", resp.text[:300])
+                except (ValueError, KeyError):
+                    msg = resp.text[:300]
+                raise ApiError(resp.status_code, msg)
 
-            return response
+            return resp
 
-    def get_paginated(self, endpoint: str, params: Dict = None) -> Generator[Dict, None, None]:
+    # -- Paginated GET -------------------------------------------------------
+
+    def get_paginated(self, endpoint: str,
+                      params: Optional[Dict[str, Any]] = None,
+                      ) -> Generator[Dict[str, Any], None, None]:
         if params is None:
             params = {}
-        params['per_page'] = 100
-        
-        url = f"{self.base_url}{endpoint}"
-        
+        params["per_page"] = PER_PAGE
+
+        url = f"{self._base_url}{endpoint}"
         while url:
-            response = self._request('GET', url.replace(self.base_url, ''), params=params)
-            
-            items = response.json()
-            if not isinstance(items, list):
-                # Some endpoints return a dict, but for lists we expect a list
-                yield items
+            resp = self._get(url, params=params)
+            data = resp.json()
+
+            if isinstance(data, list):
+                yield from data
+            else:
+                yield data
                 return
 
-            for item in items:
-                yield item
-            
-            # Handle pagination links
-            if 'next' in response.links:
-                url = response.links['next']['url']
-                params = {} # Params are usually encoded in the next link
-            else:
-                url = None
+            url = resp.links.get("next", {}).get("url")
+            params = {}  # encoded in the next URL
 
-def fetch_repos(client: GitHubClient, org: str, max_repos: Optional[int] = None) -> Generator[Dict, None, None]:
-    """Yields repositories for the organization."""
-    count = 0
+
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+def fetch_repos(client: GitHubClient, org: str,
+                max_repos: Optional[int] = None) -> List[Dict[str, Any]]:
+    """Eagerly fetch all repos so we know the total count for progress."""
+    repos: List[Dict[str, Any]] = []
+    for repo in client.get_paginated(f"/orgs/{org}/repos"):
+        repos.append(repo)
+        if max_repos and len(repos) >= max_repos:
+            break
+    return repos
+
+
+def _fetch_branches(client: GitHubClient, repo_full_name: str) -> List[str]:
     try:
-        # Try fetching org repos
-        for repo in client.get_paginated(f"/orgs/{org}/repos"):
-            yield repo
-            count += 1
-            if max_repos and count >= max_repos:
-                break
-    except Exception as e:
-        raise Exception(f"Failed to fetch repos for org '{org}': {e}")
+        return [
+            b["name"]
+            for b in client.get_paginated(
+                f"/repos/{repo_full_name}/branches",
+            )
+        ]
+    except ApiError as exc:
+        with client._print_lock:
+            click.echo(
+                f"  Warning: could not list branches for "
+                f"{repo_full_name} ({exc})",
+                err=True,
+            )
+        return []
 
-def fetch_branches(client: GitHubClient, repo_full_name: str) -> List[str]:
-    """Fetches all branch names for a repository."""
-    branches = []
-    try:
-        for branch in client.get_paginated(f"/repos/{repo_full_name}/branches"):
-            branches.append(branch['name'])
-    except Exception as e:
-        click.echo(f"Warning: Failed to fetch branches for {repo_full_name}: {e}", err=True)
-    return branches
 
-def fetch_commits(client: GitHubClient, repo_full_name: str, since: str, until: str, sha: Optional[str] = None) -> Generator[Dict, None, None]:
-    """Yields commits for a repository within the time window.
-    
-    Args:
-        client: GitHub API client
-        repo_full_name: Full repository name (owner/repo)
-        since: ISO 8601 timestamp for start of window
-        until: ISO 8601 timestamp for end of window
-        sha: Optional branch name or SHA to filter commits (e.g., 'main', 'master')
-    """
-    params = {'since': since, 'until': until}
+def _fetch_commits(client: GitHubClient, repo_full_name: str,
+                   since: str, until: str,
+                   sha: Optional[str] = None,
+                   ) -> Generator[Dict[str, Any], None, None]:
+    params: Dict[str, str] = {"since": since, "until": until}
     if sha:
-        params['sha'] = sha
+        params["sha"] = sha
     try:
-        for commit in client.get_paginated(f"/repos/{repo_full_name}/commits", params=params):
-            yield commit
-    except Exception as e:
-        # If a repo is empty or other issue, just log to stderr and continue
-        click.echo(f"Warning: Failed to fetch commits for {repo_full_name}: {e}", err=True)
+        yield from client.get_paginated(
+            f"/repos/{repo_full_name}/commits", params=params,
+        )
+    except ApiError as exc:
+        with client._print_lock:
+            click.echo(
+                f"  Warning: commits skipped for "
+                f"{repo_full_name} ({exc})",
+                err=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Repo scanner (unit of work for the thread pool)
+# ---------------------------------------------------------------------------
+
+def _scan_repo(
+    client: GitHubClient,
+    repo: Dict[str, Any],
+    since_iso: str,
+    until_iso: str,
+    default_branch_only: bool,
+    exclude_bots: bool,
+) -> Dict[str, Any]:
+    """Scan a single repo; returns local contributor data (thread-safe)."""
+    repo_name: str = repo["full_name"]
+    default_branch: Optional[str] = repo.get("default_branch")
+
+    if default_branch_only:
+        branches = [default_branch] if default_branch else []
+    else:
+        branches = _fetch_branches(client, repo_name)
+
+    local_contribs: Dict[str, Set[str]] = {}
+    local_shas: Set[str] = set()
+    commit_count = 0
+
+    for branch in branches:
+        for commit in _fetch_commits(
+            client, repo_name, since_iso, until_iso, sha=branch,
+        ):
+            sha = commit.get("sha")
+            if sha in local_shas:
+                continue
+            local_shas.add(sha)
+            commit_count += 1
+
+            author = commit.get("author")
+            commit_author = commit.get("commit", {}).get("author", {})
+
+            if not author or "login" not in author:
+                continue
+
+            login: str = author["login"]
+            if exclude_bots:
+                if (author.get("type") == "Bot"
+                        or login.lower().endswith("[bot]")):
+                    continue
+
+            email: Optional[str] = commit_author.get("email")
+            if login not in local_contribs:
+                local_contribs[login] = set()
+            if email:
+                local_contribs[login].add(email)
+
+    return {
+        "repo_name": repo_name,
+        "branch_count": len(branches),
+        "commit_count": commit_count,
+        "contributors": local_contribs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 @click.command()
-@click.option('--org', '-o', required=True, help='GitHub organization name.')
-@click.option('--token', '-t', help='GitHub Personal Access Token. Overrides GITHUB_TOKEN env var.')
-@click.option('--base-url', default=DEFAULT_BASE_URL, help='GitHub API Base URL.')
-@click.option('--format', 'output_format', type=click.Choice(['text', 'json']), default='text', help='Output format.')
-@click.option('--max-repos', type=int, help='Limit the number of repositories to process (for testing/large orgs).')
-@click.option('--list-contributors', is_flag=True, help='List individual contributors and their emails.')
-@click.option('--default-branch-only', is_flag=True, help='Only count commits from each repository\'s default branch.')
-@click.option('--exclude-bots', is_flag=True, help='Exclude bot accounts from the contributor count.')
-def main(org, token, base_url, output_format, max_repos, list_contributors, default_branch_only, exclude_bots):
-    """
-    Calculate unique contributors for a GitHub Org over the last 90 days.
-    """
-    # Resolve token
+@click.option("--org", "-o", required=True,
+              help="GitHub organization name.")
+@click.option("--token", "-t",
+              help="GitHub PAT (overrides GITHUB_TOKEN env var).")
+@click.option("--base-url", default=DEFAULT_BASE_URL,
+              help="GitHub API base URL (for GHES).")
+@click.option("--format", "output_format",
+              type=click.Choice(["text", "json"]), default="text",
+              help="Output format.")
+@click.option("--max-repos", type=int,
+              help="Cap the number of repos to scan (useful for testing).")
+@click.option("--list-contributors", is_flag=True,
+              help="Include per-contributor detail in output.")
+@click.option("--default-branch-only", is_flag=True,
+              help="Only scan each repo's default branch.")
+@click.option("--exclude-bots", is_flag=True,
+              help="Exclude bot accounts from the count.")
+def main(
+    org: str,
+    token: Optional[str],
+    base_url: str,
+    output_format: str,
+    max_repos: Optional[int],
+    list_contributors: bool,
+    default_branch_only: bool,
+    exclude_bots: bool,
+) -> None:
+    """Count unique contributors for a GitHub org over the last 90 days."""
+    t0 = time.monotonic()
+
+    # -- Resolve token -------------------------------------------------------
     if not token:
         token = os.environ.get(ENV_VAR_TOKEN)
-
-    if not token and output_format == 'text':
-        click.echo("Note: No token provided. Using anonymous access (lower rate limits).", err=True)
+    if not token and output_format == "text":
+        click.echo(
+            "Note: No token provided. Using anonymous access "
+            "(lower rate limits).",
+            err=True,
+        )
 
     client = GitHubClient(token, base_url)
 
-    # Calculate window (90 days)
+    # -- Time window ---------------------------------------------------------
     now = datetime.datetime.now(datetime.timezone.utc)
-    days = 90
-    start_date = now - datetime.timedelta(days=days)
-    
-    # ISO 8601 format for GitHub API
-    since_iso = start_date.isoformat()
+    since_iso = (now - datetime.timedelta(days=90)).isoformat()
     until_iso = now.isoformat()
 
-    # Map login -> Set of emails
-    contributors_map: Dict[str, Set[str]] = {}
-    # Track seen commit SHAs to avoid double-counting across branches
-    seen_commit_shas: Set[str] = set()
-    repo_count = 0
-    
-    if output_format == 'text':
-        click.echo(f"Fetching repositories for {org}...")
+    # -- Fetch repo list -----------------------------------------------------
+    if output_format == "text":
+        click.echo(f"Fetching repositories for {org} ...")
 
     try:
         repos = fetch_repos(client, org, max_repos)
-        
-        for repo in repos:
-            repo_count += 1
-            repo_name = repo['full_name']
-            default_branch = repo.get('default_branch')
-            
-            # Determine which branches to scan
-            if default_branch_only:
-                branches_to_scan = [default_branch] if default_branch else []
-                branch_info = f" (branch: {default_branch})"
-            else:
-                branches_to_scan = fetch_branches(client, repo_name)
-                branch_info = f" (all {len(branches_to_scan)} branches)"
-            
-            if output_format == 'text':
-                click.echo(f"Scanning {repo_name}{branch_info}...", nl=False)
-                sys.stdout.flush()
-
-            commit_count = 0
-            for branch in branches_to_scan:
-                commits = fetch_commits(client, repo_name, since_iso, until_iso, sha=branch)
-                
-                for commit in commits:
-                    commit_sha = commit.get('sha')
-                    
-                    # Skip if we've already processed this commit (from another branch)
-                    if commit_sha in seen_commit_shas:
-                        continue
-                    seen_commit_shas.add(commit_sha)
-                    
-                    commit_count += 1
-                    author = commit.get('author')
-                    commit_author_info = commit.get('commit', {}).get('author', {})
-                    
-                    if author and 'login' in author:
-                        login = author['login']
-                        author_type = author.get('type', 'User')
-                        
-                        # Skip bots if --exclude-bots is enabled
-                        if exclude_bots:
-                            # Check if GitHub identifies this as a Bot
-                            if author_type == 'Bot':
-                                continue
-                            # Check for [bot] suffix in username (case-insensitive)
-                            if login.lower().endswith('[bot]'):
-                                continue
-                        
-                        email = commit_author_info.get('email')
-                        
-                        if login not in contributors_map:
-                            contributors_map[login] = set()
-                        
-                        if email:
-                            contributors_map[login].add(email)
-            
-            if output_format == 'text':
-                click.echo(f" Done. ({commit_count} unique commits fetched)")
-
-    except Exception as e:
-        click.echo(f"\nError: {e}", err=True)
+    except ApiError as exc:
+        click.echo(f"Error: {exc}", err=True)
         sys.exit(1)
 
-    total_contributors = len(contributors_map)
+    total_repos = len(repos)
+    if output_format == "text":
+        click.echo(f"  Found {total_repos} repositories.\n")
 
-    if output_format == 'json':
-        json_output = {
+    if total_repos == 0:
+        if output_format == "json":
+            click.echo(json.dumps({
+                "org": org, "scan_date": now.strftime("%Y-%m-%d"),
+                "contributors_90d": 0, "repositories_scanned": 0,
+            }, indent=2))
+        else:
+            click.echo("  No repositories found.")
+        sys.exit(0)
+
+    # -- Scan repos (threaded) -----------------------------------------------
+    global_contribs: Dict[str, Set[str]] = {}
+    completed = 0
+    total_commits = 0
+    workers = min(DEFAULT_WORKERS, total_repos)
+
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(
+                    _scan_repo, client, repo,
+                    since_iso, until_iso,
+                    default_branch_only, exclude_bots,
+                ): repo
+                for repo in repos
+            }
+
+            for future in as_completed(futures):
+                completed += 1
+                try:
+                    result = future.result()
+                except Exception as exc:
+                    if output_format == "text":
+                        click.echo(
+                            f"  Warning: repo scan failed: {exc}", err=True,
+                        )
+                    continue
+
+                # Merge results into global map
+                for login, emails in result["contributors"].items():
+                    if login not in global_contribs:
+                        global_contribs[login] = set()
+                    global_contribs[login].update(emails)
+
+                total_commits += result["commit_count"]
+
+                if output_format == "text":
+                    rn = result["repo_name"]
+                    bc = result["branch_count"]
+                    cc = result["commit_count"]
+                    pad = len(str(total_repos))
+                    b_label = (
+                        "default branch"
+                        if default_branch_only
+                        else f"{bc} branch{'es' if bc != 1 else ''}"
+                    )
+                    click.echo(
+                        f"  [{completed:>{pad}}/{total_repos}] "
+                        f"{rn} ({b_label}) "
+                        f"... {cc:,} commits"
+                    )
+
+    except KeyboardInterrupt:
+        click.echo("\nScan interrupted by user.", err=True)
+        sys.exit(130)
+
+    elapsed = time.monotonic() - t0
+    total_contributors = len(global_contribs)
+
+    # -- Output --------------------------------------------------------------
+    if output_format == "json":
+        payload: Dict[str, Any] = {
             "org": org,
-            "scan_date": now.strftime('%Y-%m-%d'),
+            "scan_date": now.strftime("%Y-%m-%d"),
+            "repositories_scanned": total_repos,
             "default_branch_only": default_branch_only,
             "exclude_bots": exclude_bots,
-            "contributors_90d": total_contributors
+            "elapsed_seconds": round(elapsed, 1),
+            "contributors_90d": total_contributors,
         }
-        
         if list_contributors:
-            json_output["contributors_details"] = [
-                {"login": login, "emails": sorted(list(emails))}
-                for login, emails in sorted(contributors_map.items())
+            payload["contributors_details"] = [
+                {"login": login, "emails": sorted(emails)}
+                for login, emails in sorted(global_contribs.items())
             ]
-            
-        click.echo(json.dumps(json_output, indent=2))
+        click.echo(json.dumps(payload, indent=2))
     else:
-        click.echo("\n" + "="*40)
-        click.echo(f"Organization: {org}")
-        click.echo(f"Scan Date: {now.strftime('%Y-%m-%d')}")
-        click.echo(f"Repositories scanned: {repo_count}")
-        click.echo(f"Default branch only: {'Yes' if default_branch_only else 'No'}")
-        click.echo(f"Bots excluded: {'Yes' if exclude_bots else 'No'}")
-        click.echo("-" * 40)
-        click.echo(f"Contributors in last 90 days: {total_contributors}")
-        
-        if list_contributors:
-            click.echo("-" * 40)
-            click.echo("Contributors:")
-            for login in sorted(contributors_map.keys()):
-                emails = ", ".join(sorted(contributors_map[login]))
-                click.echo(f"  - {login} ({emails})")
-                
-        click.echo("="*40)
+        rows: List[Tuple[str, str]] = [
+            ("Organization:", org),
+            ("Scan Date:", now.strftime("%Y-%m-%d")),
+            ("Repositories Scanned:", str(total_repos)),
+            ("Total Commits:", f"{total_commits:,}"),
+            ("Scan Mode:",
+             "Default branch" if default_branch_only else "All branches"),
+            ("Bots Excluded:", "Yes" if exclude_bots else "No"),
+            ("Elapsed:", _elapsed(elapsed)),
+        ]
+        _summary_box(
+            "GitHub Contributors - 90 Day Report",
+            rows,
+            "Unique Contributors:", str(total_contributors),
+        )
 
-if __name__ == '__main__':
+        if list_contributors:
+            click.echo("\n  Contributors:")
+            for login in sorted(global_contribs):
+                emails_str = (
+                    ", ".join(sorted(global_contribs[login])) or "N/A"
+                )
+                click.echo(f"    {login:<30} {emails_str}")
+            click.echo()
+
+
+if __name__ == "__main__":
     main()

--- a/GitHub/requirements.txt
+++ b/GitHub/requirements.txt
@@ -1,2 +1,2 @@
-requests
-click
+requests>=2.28.0
+click>=8.0

--- a/Gitlab/gitlab_contributor_count.py
+++ b/Gitlab/gitlab_contributor_count.py
@@ -2,226 +2,341 @@
 """
 GitLab Contributors Count Tool
 
-Purpose:
-  Calculates the number of unique contributing developers across all accessible
-  GitLab groups and projects over the last 90 days.
-
-Requirements:
-  Python 3.6+
-  Dependencies: python-gitlab, click
-
-Installation:
-  pip install -r requirements.txt
+Calculates the number of unique contributing developers across all accessible
+GitLab groups and projects over the last 90 days.
 
 Usage:
-  # GitLab.com (SaaS)
   export GITLAB_TOKEN=glpat-...
   python gitlab_contributor_count.py
 
   # Self-hosted GitLab
   python gitlab_contributor_count.py --url https://gitlab.mycompany.com
 
-  # JSON output
-  python gitlab_contributor_count.py --format json
-
-Token Scopes:
-  - read_api
-  - read_user
+Token scopes:
+  read_api, read_user
 """
 
 import os
 import sys
 import json
+import time
 import datetime
-from typing import Dict, Set
+from typing import Dict, Set, List, Tuple, Optional
 
 import gitlab
 import click
 
-
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
 DEFAULT_GITLAB_URL = "https://gitlab.com"
 ENV_VAR_TOKEN = "GITLAB_TOKEN"
+REQUEST_TIMEOUT = 30  # seconds
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _elapsed(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    return f"{m}m {s}s" if m else f"{s}s"
 
 
-def parse_commit_date(created_at: str) -> datetime.datetime:
+def _summary_box(title: str, rows: List[Tuple[str, str]],
+                 result_label: str, result_value: str) -> None:
+    w = 48
+    click.echo()
+    click.echo("=" * w)
+    click.echo(f"  {title}")
+    click.echo("=" * w)
+    for label, value in rows:
+        click.echo(f"  {label:<26}{value}")
+    click.echo("-" * w)
+    click.echo(f"  {result_label:<26}{result_value}")
+    click.echo("=" * w)
+
+
+def _parse_commit_date(created_at: str) -> datetime.datetime:
     """Parse a GitLab commit timestamp into a datetime object."""
     try:
-        return datetime.datetime.fromisoformat(created_at.rstrip('Z'))
+        return datetime.datetime.fromisoformat(created_at.rstrip("Z"))
     except ValueError:
-        return datetime.datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f%z")
+        return datetime.datetime.strptime(
+            created_at, "%Y-%m-%dT%H:%M:%S.%f%z",
+        )
 
 
-def process_commits(project, since_iso: str, contributors: Dict[str, dict],
-                    unique_contributors: Dict[str, dict], gitlab_url: str):
-    """Process commits for a project and update contributor maps.
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+def _process_project(
+    gl_client: gitlab.Gitlab,
+    project_id: int,
+    since_iso: str,
+    contributors: Dict[str, dict],
+    unique_contributors: Dict[str, dict],
+    gitlab_url: str,
+) -> int:
+    """Process commits for a single project and update contributor maps.
 
     Uses author_email as the primary dedup key (falls back to author_name).
-    Stores the most recent commit info per contributor for reporting.
+    Returns the number of commits processed.
     """
-    commits = project.commits.list(since=since_iso, all=True)
+    try:
+        project = gl_client.projects.get(project_id)
+    except gitlab.exceptions.GitlabGetError as exc:
+        click.echo(
+            f"  Warning: could not access project {project_id} "
+            f"({exc.response_code})",
+            err=True,
+        )
+        return 0
+
+    project_path: str = project.path_with_namespace
+
+    try:
+        commits = project.commits.list(since=since_iso, all=True)
+    except gitlab.exceptions.GitlabListError as exc:
+        click.echo(
+            f"  Warning: could not list commits for {project_path} "
+            f"({exc.response_code})",
+            err=True,
+        )
+        return 0
+
+    commit_count = 0
     for commit in commits:
-        email = commit.author_email
-        name = commit.author_name
+        commit_count += 1
+        email: Optional[str] = getattr(commit, "author_email", None)
+        name: Optional[str] = getattr(commit, "author_name", None)
         identifier = email if email else name
 
         if not identifier:
             continue
 
-        commit_date = parse_commit_date(commit.created_at)
-        # Use path_with_namespace for correct commit URLs
-        project_path = project.path_with_namespace
-        commit_info = {
-            'name': name,
-            'email': email,
-            'date': commit_date,
-            'sha': commit.id,
-            'project_path': project_path,
+        commit_date = _parse_commit_date(commit.created_at)
+        info = {
+            "name": name or "",
+            "email": email or "",
+            "date": commit_date,
+            "sha": commit.id,
+            "project_path": project_path,
         }
 
-        if identifier not in contributors or commit_date > contributors[identifier]['date']:
-            contributors[identifier] = commit_info
+        if (identifier not in contributors
+                or commit_date > contributors[identifier]["date"]):
+            contributors[identifier] = info
 
-        if identifier not in unique_contributors or commit_date > unique_contributors[identifier]['date']:
-            unique_contributors[identifier] = commit_info
+        if (identifier not in unique_contributors
+                or commit_date > unique_contributors[identifier]["date"]):
+            unique_contributors[identifier] = info
 
+    return commit_count
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 @click.command()
-@click.option('--url', '-u', default=DEFAULT_GITLAB_URL,
-              help='GitLab instance URL (default: https://gitlab.com).')
-@click.option('--token', '-t', help='GitLab Personal Access Token. Overrides GITLAB_TOKEN env var.')
-@click.option('--format', 'output_format', type=click.Choice(['text', 'json']), default='text',
-              help='Output format.')
-@click.option('--list-contributors', is_flag=True, help='List individual contributors and their emails.')
-def main(url, token, output_format, list_contributors):
-    """
-    Calculate unique contributors across all accessible GitLab groups and projects
-    over the last 90 days.
-    """
+@click.option("--url", "-u", default=DEFAULT_GITLAB_URL,
+              help="GitLab instance URL (default: https://gitlab.com).")
+@click.option("--token", "-t",
+              help="GitLab PAT (overrides GITLAB_TOKEN env var).")
+@click.option("--format", "output_format",
+              type=click.Choice(["text", "json"]), default="text",
+              help="Output format.")
+@click.option("--list-contributors", is_flag=True,
+              help="Include per-contributor detail in output.")
+def main(
+    url: str,
+    token: Optional[str],
+    output_format: str,
+    list_contributors: bool,
+) -> None:
+    """Count unique contributors across all accessible GitLab groups and projects
+    over the last 90 days."""
+    t0 = time.monotonic()
+
     if not token:
         token = os.environ.get(ENV_VAR_TOKEN)
-
     if not token:
-        click.echo("Error: GITLAB_TOKEN is required. Set it as an environment variable or pass --token.", err=True)
+        click.echo(
+            "Error: GITLAB_TOKEN is required. "
+            "Set it via env var or --token.",
+            err=True,
+        )
         sys.exit(1)
 
-    gl = gitlab.Gitlab(url, private_token=token)
+    # python-gitlab handles retries and timeouts natively
+    gl = gitlab.Gitlab(
+        url,
+        private_token=token,
+        timeout=REQUEST_TIMEOUT,
+        retry_transient_errors=True,
+        user_agent="contributors-count/1.0",
+    )
 
     now = datetime.datetime.now(datetime.timezone.utc)
-    ninety_days_ago = now - datetime.timedelta(days=90)
-    since_iso = ninety_days_ago.isoformat()
+    since_iso = (now - datetime.timedelta(days=90)).isoformat()
 
     # group_name -> { identifier -> commit_info }
     all_contributors: Dict[str, Dict[str, dict]] = {}
-    # global deduped map: identifier -> commit_info
+    # global deduped: identifier -> commit_info
     unique_contributors: Dict[str, dict] = {}
-    # track project IDs already scanned via groups to avoid double-processing
+    # avoid double-processing projects seen via groups
     scanned_project_ids: Set[int] = set()
+    total_commits = 0
 
-    # --- Scan group projects ---
-    if output_format == 'text':
-        click.echo("Fetching groups...")
+    # -- Scan group projects -------------------------------------------------
+    if output_format == "text":
+        click.echo("Fetching groups ...")
 
-    for group in gl.groups.list(all=True):
-        group_name = group.name
-        if output_format == 'text':
-            click.echo(f"\nAnalyzing group: {group_name}")
+    try:
+        groups = gl.groups.list(all=True)
+    except gitlab.exceptions.GitlabListError as exc:
+        click.echo(f"Error listing groups: {exc}", err=True)
+        sys.exit(1)
+
+    for group in groups:
+        group_name: str = group.name
+        if output_format == "text":
+            click.echo(f"\n  Group: {group_name}")
 
         contributors: Dict[str, dict] = {}
 
-        for group_project in group.projects.list(all=True):
-            project = gl.projects.get(group_project.id)
-            scanned_project_ids.add(project.id)
-            if output_format == 'text':
-                click.echo(f"  Scanning project: {project.name}...", nl=False)
+        try:
+            group_projects = group.projects.list(all=True)
+        except gitlab.exceptions.GitlabListError:
+            click.echo(
+                f"  Warning: could not list projects in {group_name}",
+                err=True,
+            )
+            all_contributors[group_name] = contributors
+            continue
+
+        for gp in group_projects:
+            scanned_project_ids.add(gp.id)
+            if output_format == "text":
+                click.echo(f"    {gp.name} ...", nl=False)
                 sys.stdout.flush()
 
-            process_commits(project, since_iso, contributors, unique_contributors, url)
+            cc = _process_project(
+                gl, gp.id, since_iso,
+                contributors, unique_contributors, url,
+            )
+            total_commits += cc
 
-            if output_format == 'text':
-                click.echo(" Done.")
+            if output_format == "text":
+                click.echo(f" {cc:,} commits")
 
         all_contributors[group_name] = contributors
 
-    # --- Scan standalone / membership projects not already covered by groups ---
-    if output_format == 'text':
-        click.echo("\nAnalyzing standalone/membership projects:")
+    # -- Scan standalone / membership projects --------------------------------
+    if output_format == "text":
+        click.echo("\n  Standalone / membership projects:")
 
     standalone_contributors: Dict[str, dict] = {}
-    for project in gl.projects.list(membership=True, all=True):
+    try:
+        membership_projects = gl.projects.list(membership=True, all=True)
+    except gitlab.exceptions.GitlabListError as exc:
+        click.echo(
+            f"  Warning: could not list membership projects: {exc}",
+            err=True,
+        )
+        membership_projects = []
+
+    for project in membership_projects:
         if project.id in scanned_project_ids:
             continue
         scanned_project_ids.add(project.id)
 
-        if output_format == 'text':
-            click.echo(f"  Scanning project: {project.name}...", nl=False)
+        if output_format == "text":
+            click.echo(f"    {project.name} ...", nl=False)
             sys.stdout.flush()
 
-        process_commits(project, since_iso, standalone_contributors, unique_contributors, url)
+        cc = _process_project(
+            gl, project.id, since_iso,
+            standalone_contributors, unique_contributors, url,
+        )
+        total_commits += cc
 
-        if output_format == 'text':
-            click.echo(" Done.")
+        if output_format == "text":
+            click.echo(f" {cc:,} commits")
 
     all_contributors["Standalone Projects"] = standalone_contributors
 
-    # --- Output ---
+    elapsed = time.monotonic() - t0
     total_contributors = len(unique_contributors)
+    total_projects = len(scanned_project_ids)
 
-    if output_format == 'json':
-        json_output = {
+    # -- Output --------------------------------------------------------------
+    if output_format == "json":
+        payload = {
             "gitlab_url": url,
-            "scan_date": now.strftime('%Y-%m-%d'),
+            "scan_date": now.strftime("%Y-%m-%d"),
+            "projects_scanned": total_projects,
+            "elapsed_seconds": round(elapsed, 1),
             "contributors_90d": total_contributors,
-            "groups": {}
+            "groups": {},
         }
-
-        for group_name, contributors in all_contributors.items():
-            json_output["groups"][group_name] = {
-                "contributors_90d": len(contributors)
+        for group_name, contribs in all_contributors.items():
+            payload["groups"][group_name] = {
+                "contributors_90d": len(contribs),
             }
-
         if list_contributors:
-            json_output["contributors_details"] = [
+            payload["contributors_details"] = [
                 {
                     "identifier": ident,
-                    "name": info['name'],
-                    "email": info.get('email', ''),
-                    "last_commit_date": info['date'].strftime('%Y-%m-%d %H:%M:%S'),
-                    "last_commit_url": f"{url}/{info['project_path']}/-/commit/{info['sha']}"
+                    "name": info["name"],
+                    "email": info["email"],
+                    "last_commit_date": info["date"].strftime(
+                        "%Y-%m-%d %H:%M:%S",
+                    ),
+                    "last_commit_url": (
+                        f"{url}/{info['project_path']}"
+                        f"/-/commit/{info['sha']}"
+                    ),
                 }
                 for ident, info in sorted(unique_contributors.items())
             ]
-
-        click.echo(json.dumps(json_output, indent=2))
+        click.echo(json.dumps(payload, indent=2))
     else:
-        # Per-group summary
-        for group_name, contributors in all_contributors.items():
-            click.echo(f"\nContributing developers in {group_name}: {len(contributors)}")
+        rows: List[Tuple[str, str]] = [
+            ("GitLab URL:", url),
+            ("Scan Date:", now.strftime("%Y-%m-%d")),
+            ("Projects Scanned:", str(total_projects)),
+            ("Total Commits:", f"{total_commits:,}"),
+            ("Elapsed:", _elapsed(elapsed)),
+        ]
 
-            if list_contributors:
-                for ident, info in sorted(contributors.items(), key=lambda x: x[1]['date'], reverse=True):
-                    commit_url = f"{url}/{info['project_path']}/-/commit/{info['sha']}"
-                    click.echo(f"  - {info['name']} ({info.get('email', 'N/A')}): "
-                               f"{info['date'].strftime('%Y-%m-%d %H:%M:%S')} UTC")
-                    click.echo(f"    Commit: {commit_url}")
+        # Per-group breakdown
+        for group_name, contribs in all_contributors.items():
+            rows.append((f"  {group_name}:", str(len(contribs))))
 
-        # Consolidated
-        click.echo("\n" + "=" * 40)
-        click.echo(f"GitLab URL: {url}")
-        click.echo(f"Scan Date: {now.strftime('%Y-%m-%d')}")
-        click.echo("-" * 40)
-        click.echo(f"Total unique contributors in last 90 days: {total_contributors}")
+        _summary_box(
+            "GitLab Contributors - 90 Day Report",
+            rows,
+            "Unique Contributors:", str(total_contributors),
+        )
 
         if list_contributors:
-            click.echo("-" * 40)
-            click.echo("All contributors:")
-            for ident, info in sorted(unique_contributors.items(), key=lambda x: x[1]['date'], reverse=True):
-                commit_url = f"{url}/{info['project_path']}/-/commit/{info['sha']}"
-                click.echo(f"  - {info['name']} ({info.get('email', 'N/A')}): "
-                           f"{info['date'].strftime('%Y-%m-%d %H:%M:%S')} UTC")
-                click.echo(f"    Commit: {commit_url}")
+            click.echo("\n  Contributors:")
+            for ident, info in sorted(
+                unique_contributors.items(),
+                key=lambda x: x[1]["date"],
+                reverse=True,
+            ):
+                commit_url = (
+                    f"{url}/{info['project_path']}/-/commit/{info['sha']}"
+                )
+                display = info["name"] or ident
+                email_display = info["email"] or "N/A"
+                click.echo(f"    {display:<30} {email_display}")
+                click.echo(f"      {commit_url}")
+            click.echo()
 
-        click.echo("=" * 40)
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/Gitlab/requirements.txt
+++ b/Gitlab/requirements.txt
@@ -1,2 +1,2 @@
 python-gitlab>=3.12.0
-click
+click>=8.0

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # Contributing Developers Count
 
-## Github
+A collection of CLI tools that count unique contributing developers over the last 90 days across GitHub, GitLab, Bitbucket, and Azure DevOps. All tools feature automatic retry with exponential backoff, connection timeouts, rate-limit handling, and clean summary output suitable for customer-facing sizing exercises.
+
+**Requirements:** Python 3.6+
+
+## GitHub
 
 - Counts the number of contributing developers within the last 90 days of a given GitHub Organization
 - Scans all branches by default to capture contributors on feature branches (not just merged code)
 - Supports filtering to only count commits from each repository's default branch with `--default-branch-only`
+- Scans repositories concurrently (4 workers) for faster execution on large orgs
 - Prints the name of each GitHub user along with their email addresses
+- Supports GitHub Enterprise Server via `--base-url`
 - A GitHub PAT is recommended for authentication (required for private orgs). The permissions needed are shown below:
     - **Fine-grained tokens (recommended):**
         - Repository Permissions
@@ -25,16 +31,18 @@
 
 - `--org` / `-o`: GitHub organization name (required)
 - `--token` / `-t`: GitHub PAT (overrides `GITHUB_TOKEN` env var)
+- `--base-url`: GitHub API base URL, for GitHub Enterprise Server (default: `https://api.github.com`)
 - `--default-branch-only`: Only count commits from each repository's default branch
 - `--exclude-bots`: Exclude bot accounts from the contributor count
 - `--list-contributors`: List individual contributors and their emails
 - `--format`: Output format (`text` or `json`)
-- `--max-repos`: Limit number of repositories to process
+- `--max-repos`: Limit number of repositories to process (useful for testing)
 
-## Gitlab
+## GitLab
 
 - Counts the number of contributing developers within the last 90 days across all accessible GitLab groups and projects
 - Deduplicates contributors by email address across groups and standalone projects
+- Avoids double-scanning projects that appear in both groups and membership lists
 - Prints the groups and projects that are being analyzed
 - Prints the contributor count for individual groups and standalone projects
 - Prints the consolidated deduplicated report with name of each GitLab user, along with a link to a commit they've made in the last 90 days
@@ -53,7 +61,7 @@
 - `--list-contributors`: List individual contributors and their emails
 - `--format`: Output format (`text` or `json`)
 
-Note: The token used as GITLAB_TOKEN should have `read_api` and `read_user` access.
+Note: The token used as `GITLAB_TOKEN` should have `read_api` and `read_user` access.
 
 ## Bitbucket
 
@@ -82,6 +90,7 @@ Note: The token used as GITLAB_TOKEN should have `read_api` and `read_user` acce
 
 - Counts the number of unique contributing developers within the last 90 days of a given Bitbucket Server Project
 - Uses the Bitbucket Server REST API (1.0)
+- Automatically stops paginating commits once it reaches the 90-day boundary
 
 #### Running the script:
 
@@ -101,6 +110,7 @@ Note: The token used as GITLAB_TOKEN should have `read_api` and `read_user` acce
 
 - Counts the number of unique contributing developers within the last 90 days of a given Azure DevOps Project
 - Scans all Git repositories within the project
+- Handles pagination via continuation tokens for large organizations
 - Requires a Personal Access Token (PAT) with `Code (Read)` scope
 
 ### Running the script:

--- a/azure_devops/ado_contributors_90d.py
+++ b/azure_devops/ado_contributors_90d.py
@@ -2,224 +2,339 @@
 """
 Azure DevOps Contributors Count Tool
 
-Purpose:
-  Calculates the number of unique contributing developers in an Azure DevOps Project
-  over the last 90 days.
-
-Requirements:
-  Python 3.6+
-  Dependencies: requests, click
-
-Installation:
-  pip install -r requirements.txt
+Calculates the number of unique contributing developers in an Azure DevOps
+Project over the last 90 days.
 
 Usage:
-  # Basic usage (requires token)
   export ADO_TOKEN=your_pat
   python ado_contributors_90d.py --org https://dev.azure.com/myorg --project myproject
 
-  # JSON output
-  python ado_contributors_90d.py --org https://dev.azure.com/myorg --project myproject --format json
-
-Token Scopes:
-  - `Code (Read)`
+Token scopes:
+  Code (Read)
 """
 
 import os
+import re
 import sys
 import json
-import datetime
 import time
 import base64
-from typing import Optional, Dict, Any, Set, Generator
+import datetime
+from typing import Optional, Dict, Any, Set, List, Tuple, Generator
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 import click
 
+# ---------------------------------------------------------------------------
 # Constants
+# ---------------------------------------------------------------------------
 ENV_VAR_TOKEN = "ADO_TOKEN"
+REQUEST_TIMEOUT: Tuple[int, int] = (10, 30)
+ADO_API_VERSION = "7.1"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sanitize(text: str, max_len: int = 300) -> str:
+    if not text:
+        return "Unknown error"
+    text = re.sub(r"://[^@/]+@", "://***@", text)
+    return text[:max_len]
+
+
+def _elapsed(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    return f"{m}m {s}s" if m else f"{s}s"
+
+
+def _summary_box(title: str, rows: List[Tuple[str, str]],
+                 result_label: str, result_value: str) -> None:
+    w = 48
+    click.echo()
+    click.echo("=" * w)
+    click.echo(f"  {title}")
+    click.echo("=" * w)
+    for label, value in rows:
+        click.echo(f"  {label:<26}{value}")
+    click.echo("-" * w)
+    click.echo(f"  {result_label:<26}{result_value}")
+    click.echo("=" * w)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class ApiError(Exception):
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        super().__init__(f"HTTP {status_code}: {_sanitize(message)}")
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
 
 class ADOClient:
-    def __init__(self, token: str, org_url: str):
-        self.token = token
-        self.org_url = org_url.rstrip('/')
-        self.session = requests.Session()
-        
-        # ADO uses Basic Auth with PAT. Username is empty string.
-        if self.token:
-            auth_str = f":{self.token}"
-            b64_auth = base64.b64encode(auth_str.encode()).decode()
-            self.session.headers.update({"Authorization": f"Basic {b64_auth}"})
+    """Azure DevOps REST API client with retry and rate-limit support."""
 
-    def _request(self, method: str, url: str, params: Dict = None) -> Any:
+    def __init__(self, token: str, org_url: str) -> None:
+        self._org_url = org_url.rstrip("/")
+        self._session = requests.Session()
+
+        # ADO uses Basic Auth with empty username + PAT as password
+        if token:
+            b64 = base64.b64encode(f":{token}".encode()).decode()
+            self._session.headers["Authorization"] = f"Basic {b64}"
+
+        self._session.headers["User-Agent"] = "contributors-count/1.0"
+
+        retry = Retry(
+            total=3, backoff_factor=1,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=["GET"], raise_on_status=False,
+        )
+        adapter = HTTPAdapter(
+            max_retries=retry, pool_connections=10, pool_maxsize=10,
+        )
+        self._session.mount("https://", adapter)
+        self._session.mount("http://", adapter)
+
+    def __repr__(self) -> str:
+        return (f"ADOClient(org_url={self._org_url!r}, "
+                f"authenticated={'Authorization' in self._session.headers})")
+
+    # -- Core request --------------------------------------------------------
+
+    def _get(self, url: str,
+             params: Optional[Dict[str, Any]] = None) -> requests.Response:
         while True:
-            response = self.session.request(method, url, params=params)
-            
-            # Handle Rate Limiting (ADO uses 429)
-            if response.status_code == 429:
-                retry_after = int(response.headers.get('Retry-After', 60))
-                click.echo(f"Rate limit exceeded. Sleeping for {retry_after} seconds...", err=True)
+            try:
+                resp = self._session.get(
+                    url, params=params, timeout=REQUEST_TIMEOUT,
+                )
+            except requests.ConnectionError:
+                raise ApiError(
+                    0, "Connection failed. Check network and --org URL.",
+                )
+            except requests.Timeout:
+                raise ApiError(
+                    0, f"Request timed out after {REQUEST_TIMEOUT[1]}s.",
+                )
+
+            if resp.status_code == 429:
+                retry_after = int(resp.headers.get("Retry-After", 60))
+                click.echo(
+                    f"  Rate limit hit. Waiting {retry_after}s ...",
+                    err=True,
+                )
                 time.sleep(retry_after)
                 continue
 
-            if response.status_code != 200:
+            if resp.status_code != 200:
                 try:
-                    data = response.json()
-                    message = data.get('message', response.text)
-                except:
-                    message = response.text
-                raise Exception(f"ADO API Error ({response.status_code}): {message}")
+                    msg = resp.json().get("message", resp.text[:300])
+                except (ValueError, KeyError):
+                    msg = resp.text[:300]
+                raise ApiError(resp.status_code, msg)
 
-            return response
+            return resp
 
-    def get_paginated(self, url: str, params: Dict = None) -> Generator[Dict, None, None]:
+    # -- Paginated GET (continuation-token based) ----------------------------
+
+    def get_paginated(self, url: str,
+                      params: Optional[Dict[str, Any]] = None,
+                      ) -> Generator[Dict[str, Any], None, None]:
         if params is None:
             params = {}
 
         while True:
-            response = self._request('GET', url, params=params)
-            data = response.json()
+            resp = self._get(url, params=params)
+            data = resp.json()
+            yield from data.get("value", [])
 
-            items = data.get('value', [])
-            for item in items:
-                yield item
-
-            # ADO uses x-ms-continuationtoken header for pagination
-            continuation_token = response.headers.get('x-ms-continuationtoken')
-            if not continuation_token:
+            token = resp.headers.get("x-ms-continuationtoken")
+            if not token:
                 break
-            params['continuationToken'] = continuation_token
+            params["continuationToken"] = token
 
-def fetch_repos(client: ADOClient, project: str) -> Generator[Dict, None, None]:
-    """Yields repositories for the project."""
-    url = f"{client.org_url}/{project}/_apis/git/repositories?api-version=7.1"
-    try:
-        for repo in client.get_paginated(url):
-            yield repo
-    except Exception as e:
-        raise Exception(f"Failed to fetch repos for project '{project}': {e}")
 
-def fetch_commits(client: ADOClient, repo_id: str, project: str, since: str, until: str) -> Generator[Dict, None, None]:
-    """Yields commits for a repository within the time window."""
-    url = f"{client.org_url}/{project}/_apis/git/repositories/{repo_id}/commits?api-version=7.1"
-    
-    # ADO searchCriteria
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+def fetch_repos(client: ADOClient,
+                project: str) -> List[Dict[str, Any]]:
+    url = (
+        f"{client._org_url}/{project}"
+        f"/_apis/git/repositories?api-version={ADO_API_VERSION}"
+    )
+    repos: List[Dict[str, Any]] = []
+    for repo in client.get_paginated(url):
+        repos.append(repo)
+    return repos
+
+
+def _fetch_commits(
+    client: ADOClient,
+    project: str,
+    repo_id: str,
+    since: str,
+    until: str,
+) -> Generator[Dict[str, Any], None, None]:
+    url = (
+        f"{client._org_url}/{project}"
+        f"/_apis/git/repositories/{repo_id}"
+        f"/commits?api-version={ADO_API_VERSION}"
+    )
     params = {
-        'searchCriteria.fromDate': since,
-        'searchCriteria.toDate': until,
-        'searchCriteria.$top': 10000 # Fetch up to 10k commits. Pagination would be needed for more.
+        "searchCriteria.fromDate": since,
+        "searchCriteria.toDate": until,
+        "searchCriteria.$top": 10000,
     }
-    
     try:
-        for commit in client.get_paginated(url, params=params):
-            yield commit
-    except Exception as e:
-        click.echo(f"Warning: Failed to fetch commits for repo {repo_id}: {e}", err=True)
+        yield from client.get_paginated(url, params=params)
+    except ApiError as exc:
+        click.echo(
+            f"  Warning: commits skipped for repo {repo_id} ({exc})",
+            err=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 @click.command()
-@click.option('--org', '-o', required=True, help='Azure DevOps Org URL (e.g. https://dev.azure.com/myorg).')
-@click.option('--project', '-p', required=True, help='Project name.')
-@click.option('--token', '-t', help='Personal Access Token. Overrides ADO_TOKEN env var.')
-@click.option('--format', 'output_format', type=click.Choice(['text', 'json']), default='text', help='Output format.')
-@click.option('--list-contributors', is_flag=True, help='List individual contributors and their emails.')
-def main(org, project, token, output_format, list_contributors):
-    """
-    Calculate unique contributors for an Azure DevOps Project over the last 90 days.
-    """
+@click.option("--org", "-o", required=True,
+              help="Azure DevOps Org URL (e.g. https://dev.azure.com/myorg).")
+@click.option("--project", "-p", required=True,
+              help="Project name.")
+@click.option("--token", "-t",
+              help="Personal Access Token (overrides ADO_TOKEN env var).")
+@click.option("--format", "output_format",
+              type=click.Choice(["text", "json"]), default="text",
+              help="Output format.")
+@click.option("--list-contributors", is_flag=True,
+              help="Include per-contributor detail in output.")
+def main(
+    org: str,
+    project: str,
+    token: Optional[str],
+    output_format: str,
+    list_contributors: bool,
+) -> None:
+    """Count unique contributors for an Azure DevOps Project over the last 90 days."""
+    t0 = time.monotonic()
+
     if not token:
         token = os.environ.get(ENV_VAR_TOKEN)
-
     if not token:
         click.echo("Error: ADO_TOKEN is required.", err=True)
         sys.exit(1)
 
     client = ADOClient(token, org)
 
-    # Calculate window (90 days)
     now = datetime.datetime.now(datetime.timezone.utc)
-    days = 90
-    start_date = now - datetime.timedelta(days=days)
-    
-    since_iso = start_date.isoformat()
+    since_iso = (now - datetime.timedelta(days=90)).isoformat()
     until_iso = now.isoformat()
 
-    contributors_map: Dict[str, Set[str]] = {}
-    repo_count = 0
-    
-    if output_format == 'text':
-        click.echo(f"Fetching repositories for {project}...")
+    # -- Fetch repos ---------------------------------------------------------
+    if output_format == "text":
+        click.echo(f"Fetching repositories for {project} ...")
 
     try:
         repos = fetch_repos(client, project)
-        
-        for repo in repos:
-            repo_count += 1
-            repo_name = repo['name']
-            repo_id = repo['id']
-            
-            if output_format == 'text':
-                click.echo(f"Scanning {repo_name}...", nl=False)
-                sys.stdout.flush()
-
-            commits = fetch_commits(client, repo_id, project, since_iso, until_iso)
-            
-            commit_count = 0
-            for commit in commits:
-                commit_count += 1
-                author = commit.get('author', {})
-                email = author.get('email')
-                name = author.get('name')
-                
-                # Use email as unique identifier
-                identifier = email if email else name
-                
-                if identifier:
-                    if identifier not in contributors_map:
-                        contributors_map[identifier] = set()
-                    if email:
-                        contributors_map[identifier].add(email)
-            
-            if output_format == 'text':
-                click.echo(f" Done. ({commit_count} commits)")
-
-    except Exception as e:
-        click.echo(f"\nError: {e}", err=True)
+    except ApiError as exc:
+        click.echo(f"Error: {exc}", err=True)
         sys.exit(1)
 
+    total_repos = len(repos)
+    if output_format == "text":
+        click.echo(f"  Found {total_repos} repositories.\n")
+
+    # -- Scan repos ----------------------------------------------------------
+    contributors_map: Dict[str, Set[str]] = {}
+    total_commits = 0
+
+    for idx, repo in enumerate(repos, 1):
+        repo_name: str = repo["name"]
+        repo_id: str = repo["id"]
+
+        if output_format == "text":
+            pad = len(str(total_repos))
+            click.echo(
+                f"  [{idx:>{pad}}/{total_repos}] {repo_name} ...",
+                nl=False,
+            )
+            sys.stdout.flush()
+
+        commit_count = 0
+        for commit in _fetch_commits(
+            client, project, repo_id, since_iso, until_iso,
+        ):
+            commit_count += 1
+            author = commit.get("author", {})
+            email: Optional[str] = author.get("email")
+            name: Optional[str] = author.get("name")
+
+            identifier = email if email else name
+            if identifier:
+                if identifier not in contributors_map:
+                    contributors_map[identifier] = set()
+                if email:
+                    contributors_map[identifier].add(email)
+
+        total_commits += commit_count
+        if output_format == "text":
+            click.echo(f" {commit_count:,} commits")
+
+    elapsed = time.monotonic() - t0
     total_contributors = len(contributors_map)
 
-    if output_format == 'json':
-        json_output = {
+    # -- Output --------------------------------------------------------------
+    if output_format == "json":
+        payload: Dict[str, Any] = {
             "org": org,
             "project": project,
-            "scan_date": now.strftime('%Y-%m-%d'),
-            "contributors_90d": total_contributors
+            "scan_date": now.strftime("%Y-%m-%d"),
+            "repositories_scanned": total_repos,
+            "elapsed_seconds": round(elapsed, 1),
+            "contributors_90d": total_contributors,
         }
-        
         if list_contributors:
-            json_output["contributors_details"] = [
-                {"identifier": ident, "emails": sorted(list(emails))}
+            payload["contributors_details"] = [
+                {"identifier": ident, "emails": sorted(emails)}
                 for ident, emails in sorted(contributors_map.items())
             ]
-            
-        click.echo(json.dumps(json_output, indent=2))
+        click.echo(json.dumps(payload, indent=2))
     else:
-        click.echo("\n" + "="*40)
-        click.echo(f"Organization: {org}")
-        click.echo(f"Project: {project}")
-        click.echo(f"Scan Date: {now.strftime('%Y-%m-%d')}")
-        click.echo(f"Repositories scanned: {repo_count}")
-        click.echo("-" * 40)
-        click.echo(f"Contributors in last 90 days: {total_contributors}")
-        
-        if list_contributors:
-            click.echo("-" * 40)
-            click.echo("Contributors:")
-            for ident in sorted(contributors_map.keys()):
-                emails = ", ".join(sorted(contributors_map[ident]))
-                click.echo(f"  - {ident} ({emails})")
-                
-        click.echo("="*40)
+        rows: List[Tuple[str, str]] = [
+            ("Organization:", org),
+            ("Project:", project),
+            ("Scan Date:", now.strftime("%Y-%m-%d")),
+            ("Repositories Scanned:", str(total_repos)),
+            ("Total Commits:", f"{total_commits:,}"),
+            ("Elapsed:", _elapsed(elapsed)),
+        ]
+        _summary_box(
+            "Azure DevOps Contributors - 90 Day Report",
+            rows,
+            "Unique Contributors:", str(total_contributors),
+        )
 
-if __name__ == '__main__':
+        if list_contributors:
+            click.echo("\n  Contributors:")
+            for ident in sorted(contributors_map):
+                emails_str = (
+                    ", ".join(sorted(contributors_map[ident])) or "N/A"
+                )
+                click.echo(f"    {ident:<30} {emails_str}")
+            click.echo()
+
+
+if __name__ == "__main__":
     main()

--- a/azure_devops/requirements.txt
+++ b/azure_devops/requirements.txt
@@ -1,2 +1,2 @@
-requests
-click
+requests>=2.28.0
+click>=8.0

--- a/bitbucket/bitbucket_contributors_90d.py
+++ b/bitbucket/bitbucket_contributors_90d.py
@@ -1,242 +1,334 @@
 #!/usr/bin/env python3
 """
-Bitbucket Contributors Count Tool
+Bitbucket Cloud Contributors Count Tool
 
-Purpose:
-  Calculates the number of unique contributing developers in a Bitbucket Workspace
-  over the last 90 days.
-
-Requirements:
-  Python 3.6+
-  Dependencies: requests, click
-
-Installation:
-  pip install -r requirements.txt
+Calculates the number of unique contributing developers in a Bitbucket
+Workspace over the last 90 days.
 
 Usage:
-  # Basic usage (requires App Password)
   export BITBUCKET_USER=myuser
   export BITBUCKET_PASSWORD=my_app_password
   python bitbucket_contributors_90d.py --workspace myworkspace
 
-  # JSON output
-  python bitbucket_contributors_90d.py --workspace myworkspace --format json
-
-Token Scopes:
-  - `Repositories: Read`
+Token permissions:
+  App Password -> Repositories: Read
 """
 
 import os
+import re
 import sys
 import json
-import datetime
 import time
-from typing import Optional, Dict, Any, Set, Generator
+import datetime
+from typing import Optional, Dict, Any, Set, List, Tuple, Generator
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 import click
 
+# ---------------------------------------------------------------------------
 # Constants
+# ---------------------------------------------------------------------------
 DEFAULT_BASE_URL = "https://api.bitbucket.org/2.0"
 ENV_VAR_USER = "BITBUCKET_USER"
 ENV_VAR_PASSWORD = "BITBUCKET_PASSWORD"
+REQUEST_TIMEOUT: Tuple[int, int] = (10, 30)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sanitize(text: str, max_len: int = 300) -> str:
+    if not text:
+        return "Unknown error"
+    text = re.sub(r"://[^@/]+@", "://***@", text)
+    return text[:max_len]
+
+
+def _elapsed(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    return f"{m}m {s}s" if m else f"{s}s"
+
+
+def _summary_box(title: str, rows: List[Tuple[str, str]],
+                 result_label: str, result_value: str) -> None:
+    w = 48
+    click.echo()
+    click.echo("=" * w)
+    click.echo(f"  {title}")
+    click.echo("=" * w)
+    for label, value in rows:
+        click.echo(f"  {label:<26}{value}")
+    click.echo("-" * w)
+    click.echo(f"  {result_label:<26}{result_value}")
+    click.echo("=" * w)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class ApiError(Exception):
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        super().__init__(f"HTTP {status_code}: {_sanitize(message)}")
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
 
 class BitbucketClient:
-    def __init__(self, user: str, password: str, base_url: str = DEFAULT_BASE_URL):
-        self.user = user
-        self.password = password
-        self.base_url = base_url.rstrip('/')
-        self.session = requests.Session()
-        
-        if self.user and self.password:
-            self.session.auth = (self.user, self.password)
+    """Bitbucket Cloud REST API client with retry and rate-limit support."""
 
-    def _request(self, method: str, url: str, params: Dict = None) -> Any:
+    def __init__(self, user: str, password: str,
+                 base_url: str = DEFAULT_BASE_URL) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._session = requests.Session()
+
+        if user and password:
+            self._session.auth = (user, password)
+
+        self._session.headers["User-Agent"] = "contributors-count/1.0"
+
+        retry = Retry(
+            total=3, backoff_factor=1,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=["GET"], raise_on_status=False,
+        )
+        adapter = HTTPAdapter(
+            max_retries=retry, pool_connections=10, pool_maxsize=10,
+        )
+        self._session.mount("https://", adapter)
+        self._session.mount("http://", adapter)
+
+    def __repr__(self) -> str:
+        return (f"BitbucketClient(base_url={self._base_url!r}, "
+                f"authenticated={self._session.auth is not None})")
+
+    # -- Core request --------------------------------------------------------
+
+    def _get(self, url: str,
+             params: Optional[Dict[str, Any]] = None) -> requests.Response:
         while True:
-            response = self.session.request(method, url, params=params)
-            
-            # Handle Rate Limiting
-            if response.status_code == 429:
-                # Bitbucket usually sends 'Retry-After'
-                retry_after = int(response.headers.get('Retry-After', 60))
-                click.echo(f"Rate limit exceeded. Sleeping for {retry_after} seconds...", err=True)
+            try:
+                resp = self._session.get(
+                    url, params=params, timeout=REQUEST_TIMEOUT,
+                )
+            except requests.ConnectionError:
+                raise ApiError(0, "Connection failed. Check network.")
+            except requests.Timeout:
+                raise ApiError(
+                    0, f"Request timed out after {REQUEST_TIMEOUT[1]}s.",
+                )
+
+            if resp.status_code == 429:
+                retry_after = int(resp.headers.get("Retry-After", 60))
+                click.echo(
+                    f"  Rate limit hit. Waiting {retry_after}s ...",
+                    err=True,
+                )
                 time.sleep(retry_after)
                 continue
 
-            if response.status_code != 200:
+            if resp.status_code != 200:
                 try:
-                    data = response.json()
-                    message = data.get('error', {}).get('message', response.text)
-                except:
-                    message = response.text
-                raise Exception(f"Bitbucket API Error ({response.status_code}): {message}")
+                    msg = (resp.json()
+                           .get("error", {})
+                           .get("message", resp.text[:300]))
+                except (ValueError, KeyError):
+                    msg = resp.text[:300]
+                raise ApiError(resp.status_code, msg)
 
-            return response
+            return resp
 
-    def get_paginated(self, url: str, params: Dict = None) -> Generator[Dict, None, None]:
+    # -- Paginated GET -------------------------------------------------------
+
+    def get_paginated(self, url: str,
+                      params: Optional[Dict[str, Any]] = None,
+                      ) -> Generator[Dict[str, Any], None, None]:
         if params is None:
             params = {}
-        
-        # Bitbucket pagination uses 'next' link in response
+
         while url:
-            response = self._request('GET', url, params=params)
-            data = response.json()
-            
-            items = data.get('values', [])
-            for item in items:
-                yield item
-            
-            url = data.get('next')
-            params = {} # Params are encoded in next link
+            resp = self._get(url, params=params)
+            data = resp.json()
+            yield from data.get("values", [])
+            url = data.get("next")
+            params = {}  # encoded in next URL
 
-def fetch_repos(client: BitbucketClient, workspace: str) -> Generator[Dict, None, None]:
-    """Yields repositories for the workspace."""
-    url = f"{client.base_url}/repositories/{workspace}"
-    try:
-        for repo in client.get_paginated(url):
-            yield repo
-    except Exception as e:
-        raise Exception(f"Failed to fetch repos for workspace '{workspace}': {e}")
 
-def fetch_commits(client: BitbucketClient, workspace: str, repo_slug: str, since_iso: str) -> Generator[Dict, None, None]:
-    """Yields commits for a repository since a date."""
-    # Bitbucket API doesn't have a simple 'since' param for commits endpoint in the same way.
-    # It supports `?q=date > ...` filtering if using 2.0 API properly, but sometimes it's tricky.
-    # Alternatively, we iterate until we hit a date older than 'since'.
-    # Let's try to use the `q` parameter which is powerful in Bitbucket API 2.0.
-    # Format: date > "2021-01-01T00:00:00+00:00"
-    
-    url = f"{client.base_url}/repositories/{workspace}/{repo_slug}/commits"
-    query = f'date > "{since_iso}"'
-    params = {'q': query}
-    
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+def fetch_repos(client: BitbucketClient,
+                workspace: str) -> List[Dict[str, Any]]:
+    repos: List[Dict[str, Any]] = []
+    url = f"{client._base_url}/repositories/{workspace}"
+    for repo in client.get_paginated(url):
+        repos.append(repo)
+    return repos
+
+
+def _fetch_commits(client: BitbucketClient, workspace: str,
+                   repo_slug: str,
+                   since_iso: str) -> Generator[Dict[str, Any], None, None]:
+    url = f"{client._base_url}/repositories/{workspace}/{repo_slug}/commits"
+    params = {"q": f'date > "{since_iso}"'}
     try:
-        for commit in client.get_paginated(url, params=params):
-            yield commit
-    except Exception as e:
-        click.echo(f"Warning: Failed to fetch commits for repo {repo_slug}: {e}", err=True)
+        yield from client.get_paginated(url, params=params)
+    except ApiError as exc:
+        click.echo(
+            f"  Warning: commits skipped for {repo_slug} ({exc})",
+            err=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 @click.command()
-@click.option('--workspace', '-w', required=True, help='Bitbucket Workspace ID/Slug.')
-@click.option('--user', '-u', help='Bitbucket Username. Overrides BITBUCKET_USER env var.')
-@click.option('--password', '-p', help='Bitbucket App Password. Overrides BITBUCKET_PASSWORD env var.')
-@click.option('--format', 'output_format', type=click.Choice(['text', 'json']), default='text', help='Output format.')
-@click.option('--list-contributors', is_flag=True, help='List individual contributors and their emails.')
-def main(workspace, user, password, output_format, list_contributors):
-    """
-    Calculate unique contributors for a Bitbucket Workspace over the last 90 days.
-    """
+@click.option("--workspace", "-w", required=True,
+              help="Bitbucket Workspace ID/Slug.")
+@click.option("--user", "-u",
+              help="Bitbucket username (overrides BITBUCKET_USER env var).")
+@click.option("--password", "-p",
+              help="App Password (overrides BITBUCKET_PASSWORD env var).")
+@click.option("--format", "output_format",
+              type=click.Choice(["text", "json"]), default="text",
+              help="Output format.")
+@click.option("--list-contributors", is_flag=True,
+              help="Include per-contributor detail in output.")
+def main(
+    workspace: str,
+    user: Optional[str],
+    password: Optional[str],
+    output_format: str,
+    list_contributors: bool,
+) -> None:
+    """Count unique contributors for a Bitbucket Workspace over the last 90 days."""
+    t0 = time.monotonic()
+
     if not user:
         user = os.environ.get(ENV_VAR_USER)
     if not password:
         password = os.environ.get(ENV_VAR_PASSWORD)
 
     if not user or not password:
-        click.echo("Error: BITBUCKET_USER and BITBUCKET_PASSWORD are required.", err=True)
+        click.echo(
+            "Error: BITBUCKET_USER and BITBUCKET_PASSWORD are required.",
+            err=True,
+        )
         sys.exit(1)
 
     client = BitbucketClient(user, password)
 
-    # Calculate window (90 days)
     now = datetime.datetime.now(datetime.timezone.utc)
-    days = 90
-    start_date = now - datetime.timedelta(days=days)
-    
-    since_iso = start_date.isoformat()
+    since_iso = (now - datetime.timedelta(days=90)).isoformat()
 
-    contributors_map: Dict[str, Set[str]] = {}
-    repo_count = 0
-    
-    if output_format == 'text':
-        click.echo(f"Fetching repositories for {workspace}...")
+    # -- Fetch repos ---------------------------------------------------------
+    if output_format == "text":
+        click.echo(f"Fetching repositories for {workspace} ...")
 
     try:
         repos = fetch_repos(client, workspace)
-        
-        for repo in repos:
-            repo_count += 1
-            repo_name = repo['name']
-            repo_slug = repo['slug']
-            
-            if output_format == 'text':
-                click.echo(f"Scanning {repo_name}...", nl=False)
-                sys.stdout.flush()
-
-            commits = fetch_commits(client, workspace, repo_slug, since_iso)
-            
-            commit_count = 0
-            for commit in commits:
-                commit_count += 1
-                author = commit.get('author', {})
-                raw = author.get('raw') # "Name <email>"
-                user_info = author.get('user', {})
-                
-                # Bitbucket author object:
-                # 'raw': 'Name <email>'
-                # 'user': { 'display_name': ..., 'uuid': ..., 'account_id': ... } (if mapped)
-                
-                # We want unique developers.
-                # If 'user' object exists, 'account_id' is best.
-                # If not, parse email from 'raw'.
-                
-                identifier = None
-                email = None
-                
-                if 'account_id' in user_info:
-                    identifier = user_info['account_id']
-                elif raw:
-                    # Simple parse for email
-                    if '<' in raw and '>' in raw:
-                        email = raw.split('<')[-1].strip('>')
-                        identifier = email
-                    else:
-                        identifier = raw
-                
-                if identifier:
-                    if identifier not in contributors_map:
-                        contributors_map[identifier] = set()
-                    if email:
-                        contributors_map[identifier].add(email)
-            
-            if output_format == 'text':
-                click.echo(f" Done. ({commit_count} commits)")
-
-    except Exception as e:
-        click.echo(f"\nError: {e}", err=True)
+    except ApiError as exc:
+        click.echo(f"Error: {exc}", err=True)
         sys.exit(1)
 
+    total_repos = len(repos)
+    if output_format == "text":
+        click.echo(f"  Found {total_repos} repositories.\n")
+
+    # -- Scan repos ----------------------------------------------------------
+    contributors_map: Dict[str, Set[str]] = {}
+    total_commits = 0
+
+    for idx, repo in enumerate(repos, 1):
+        repo_name: str = repo["name"]
+        repo_slug: str = repo["slug"]
+
+        if output_format == "text":
+            pad = len(str(total_repos))
+            click.echo(
+                f"  [{idx:>{pad}}/{total_repos}] {repo_name} ...",
+                nl=False,
+            )
+            sys.stdout.flush()
+
+        commit_count = 0
+        for commit in _fetch_commits(client, workspace, repo_slug, since_iso):
+            commit_count += 1
+            author = commit.get("author", {})
+            raw: Optional[str] = author.get("raw")
+            user_info: Dict[str, Any] = author.get("user", {})
+
+            identifier: Optional[str] = None
+            email: Optional[str] = None
+
+            if "account_id" in user_info:
+                identifier = user_info["account_id"]
+            elif raw:
+                if "<" in raw and ">" in raw:
+                    email = raw.split("<")[-1].strip(">")
+                    identifier = email
+                else:
+                    identifier = raw
+
+            if identifier:
+                if identifier not in contributors_map:
+                    contributors_map[identifier] = set()
+                if email:
+                    contributors_map[identifier].add(email)
+
+        total_commits += commit_count
+        if output_format == "text":
+            click.echo(f" {commit_count:,} commits")
+
+    elapsed = time.monotonic() - t0
     total_contributors = len(contributors_map)
 
-    if output_format == 'json':
-        json_output = {
+    # -- Output --------------------------------------------------------------
+    if output_format == "json":
+        payload: Dict[str, Any] = {
             "workspace": workspace,
-            "scan_date": now.strftime('%Y-%m-%d'),
-            "contributors_90d": total_contributors
+            "scan_date": now.strftime("%Y-%m-%d"),
+            "repositories_scanned": total_repos,
+            "elapsed_seconds": round(elapsed, 1),
+            "contributors_90d": total_contributors,
         }
-        
         if list_contributors:
-            json_output["contributors_details"] = [
-                {"identifier": ident, "emails": sorted(list(emails))}
+            payload["contributors_details"] = [
+                {"identifier": ident, "emails": sorted(emails)}
                 for ident, emails in sorted(contributors_map.items())
             ]
-            
-        click.echo(json.dumps(json_output, indent=2))
+        click.echo(json.dumps(payload, indent=2))
     else:
-        click.echo("\n" + "="*40)
-        click.echo(f"Workspace: {workspace}")
-        click.echo(f"Scan Date: {now.strftime('%Y-%m-%d')}")
-        click.echo(f"Repositories scanned: {repo_count}")
-        click.echo("-" * 40)
-        click.echo(f"Contributors in last 90 days: {total_contributors}")
-        
-        if list_contributors:
-            click.echo("-" * 40)
-            click.echo("Contributors:")
-            for ident in sorted(contributors_map.keys()):
-                emails = ", ".join(sorted(contributors_map[ident]))
-                click.echo(f"  - {ident} ({emails})")
-                
-        click.echo("="*40)
+        rows: List[Tuple[str, str]] = [
+            ("Workspace:", workspace),
+            ("Scan Date:", now.strftime("%Y-%m-%d")),
+            ("Repositories Scanned:", str(total_repos)),
+            ("Total Commits:", f"{total_commits:,}"),
+            ("Elapsed:", _elapsed(elapsed)),
+        ]
+        _summary_box(
+            "Bitbucket Contributors - 90 Day Report",
+            rows,
+            "Unique Contributors:", str(total_contributors),
+        )
 
-if __name__ == '__main__':
+        if list_contributors:
+            click.echo("\n  Contributors:")
+            for ident in sorted(contributors_map):
+                emails_str = (
+                    ", ".join(sorted(contributors_map[ident])) or "N/A"
+                )
+                click.echo(f"    {ident:<30} {emails_str}")
+            click.echo()
+
+
+if __name__ == "__main__":
     main()

--- a/bitbucket/bitbucket_server_contributors_90d.py
+++ b/bitbucket/bitbucket_server_contributors_90d.py
@@ -1,262 +1,376 @@
 #!/usr/bin/env python3
 """
-Bitbucket Server (Data Center) Contributors Count Tool
+Bitbucket Server / Data Center Contributors Count Tool
 
-Purpose:
-  Calculates the number of unique contributing developers in a Bitbucket Server Project
-  over the last 90 days.
-
-Requirements:
-  Python 3.6+
-  Dependencies: requests, click
-
-Installation:
-  pip install -r requirements.txt
+Calculates the number of unique contributing developers in a Bitbucket
+Server Project over the last 90 days.
 
 Usage:
-  # Basic usage (requires credentials)
-  export BITBUCKET_SERVER_URL=https://bitbucket.mycompany.com
   export BITBUCKET_USER=myuser
   export BITBUCKET_PASSWORD=mypassword
-  python bitbucket_server_contributors_90d.py --project MYPROJ
+  python bitbucket_server_contributors_90d.py \
+      --project MYPROJ --url https://bitbucket.mycompany.com
 
-  # JSON output
-  python bitbucket_server_contributors_90d.py --project MYPROJ --format json
-
-Token Scopes:
-  - Project/Repo Read permissions
+Token permissions:
+  Project / Repository Read
 """
 
 import os
+import re
 import sys
 import json
-import datetime
 import time
-from typing import Optional, Dict, Any, Set, Generator
+import datetime
+from typing import Optional, Dict, Any, Set, List, Tuple, Generator
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 import click
 
+# ---------------------------------------------------------------------------
 # Constants
+# ---------------------------------------------------------------------------
 ENV_VAR_URL = "BITBUCKET_SERVER_URL"
 ENV_VAR_USER = "BITBUCKET_USER"
 ENV_VAR_PASSWORD = "BITBUCKET_PASSWORD"
+REQUEST_TIMEOUT: Tuple[int, int] = (10, 30)
+PAGE_LIMIT = 100
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sanitize(text: str, max_len: int = 300) -> str:
+    if not text:
+        return "Unknown error"
+    text = re.sub(r"://[^@/]+@", "://***@", text)
+    return text[:max_len]
+
+
+def _elapsed(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    return f"{m}m {s}s" if m else f"{s}s"
+
+
+def _summary_box(title: str, rows: List[Tuple[str, str]],
+                 result_label: str, result_value: str) -> None:
+    w = 48
+    click.echo()
+    click.echo("=" * w)
+    click.echo(f"  {title}")
+    click.echo("=" * w)
+    for label, value in rows:
+        click.echo(f"  {label:<26}{value}")
+    click.echo("-" * w)
+    click.echo(f"  {result_label:<26}{result_value}")
+    click.echo("=" * w)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class ApiError(Exception):
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        super().__init__(f"HTTP {status_code}: {_sanitize(message)}")
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
 
 class BitbucketServerClient:
-    def __init__(self, base_url: str, user: str, password: str):
-        self.base_url = base_url.rstrip('/')
-        self.user = user
-        self.password = password
-        self.session = requests.Session()
-        
-        if self.user and self.password:
-            self.session.auth = (self.user, self.password)
+    """Bitbucket Server REST API client with retry and rate-limit support."""
 
-    def _request(self, method: str, endpoint: str, params: Dict = None) -> Any:
-        url = f"{self.base_url}{endpoint}"
+    def __init__(self, base_url: str, user: str, password: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._session = requests.Session()
+
+        if user and password:
+            self._session.auth = (user, password)
+
+        self._session.headers["User-Agent"] = "contributors-count/1.0"
+
+        retry = Retry(
+            total=3, backoff_factor=1,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=["GET"], raise_on_status=False,
+        )
+        adapter = HTTPAdapter(
+            max_retries=retry, pool_connections=10, pool_maxsize=10,
+        )
+        self._session.mount("https://", adapter)
+        self._session.mount("http://", adapter)
+
+    def __repr__(self) -> str:
+        return (f"BitbucketServerClient(base_url={self._base_url!r}, "
+                f"authenticated={self._session.auth is not None})")
+
+    # -- Core request --------------------------------------------------------
+
+    def _get(self, endpoint: str,
+             params: Optional[Dict[str, Any]] = None) -> requests.Response:
+        url = f"{self._base_url}{endpoint}"
         while True:
-            response = self.session.request(method, url, params=params)
-            
-            # Handle Rate Limiting (if applicable, usually less common on-prem)
-            if response.status_code == 429:
-                retry_after = int(response.headers.get('Retry-After', 60))
-                click.echo(f"Rate limit exceeded. Sleeping for {retry_after} seconds...", err=True)
+            try:
+                resp = self._session.get(
+                    url, params=params, timeout=REQUEST_TIMEOUT,
+                )
+            except requests.ConnectionError:
+                raise ApiError(
+                    0, "Connection failed. Check network and --url.",
+                )
+            except requests.Timeout:
+                raise ApiError(
+                    0, f"Request timed out after {REQUEST_TIMEOUT[1]}s.",
+                )
+
+            if resp.status_code == 429:
+                retry_after = int(resp.headers.get("Retry-After", 60))
+                click.echo(
+                    f"  Rate limit hit. Waiting {retry_after}s ...",
+                    err=True,
+                )
                 time.sleep(retry_after)
                 continue
 
-            if response.status_code != 200:
+            if resp.status_code != 200:
                 try:
-                    data = response.json()
-                    message = data.get('errors', [{}])[0].get('message', response.text)
-                except:
-                    message = response.text
-                raise Exception(f"Bitbucket Server API Error ({response.status_code}): {message}")
+                    errors = resp.json().get("errors", [])
+                    msg = errors[0].get("message", resp.text[:300]) if errors else resp.text[:300]
+                except (ValueError, KeyError, IndexError):
+                    msg = resp.text[:300]
+                raise ApiError(resp.status_code, msg)
 
-            return response
+            return resp
 
-    def get_paginated(self, endpoint: str, params: Dict = None) -> Generator[Dict, None, None]:
+    # -- Paginated GET (offset-based) ----------------------------------------
+
+    def get_paginated(self, endpoint: str,
+                      params: Optional[Dict[str, Any]] = None,
+                      ) -> Generator[Dict[str, Any], None, None]:
         if params is None:
             params = {}
-        
-        # Bitbucket Server pagination uses 'start' (offset) and 'limit'
-        # Response contains 'isLastPage', 'nextPageStart', 'values'
-        
+        params["limit"] = PAGE_LIMIT
         start = 0
-        limit = 100 # Default limit
-        params['limit'] = limit
-        
+
         while True:
-            params['start'] = start
-            response = self._request('GET', endpoint, params=params)
-            data = response.json()
-            
-            items = data.get('values', [])
-            for item in items:
-                yield item
-            
-            if data.get('isLastPage', True):
+            params["start"] = start
+            resp = self._get(endpoint, params=params)
+            data = resp.json()
+
+            items = data.get("values", [])
+            yield from items
+
+            if data.get("isLastPage", True):
                 break
-            
-            next_start = data.get('nextPageStart')
-            if next_start:
-                start = next_start
-            else:
-                # Fallback if nextPageStart is missing but isLastPage is false
-                start += len(items)
 
-def fetch_repos(client: BitbucketServerClient, project_key: str) -> Generator[Dict, None, None]:
-    """Yields repositories for the project."""
-    try:
-        for repo in client.get_paginated(f"/rest/api/1.0/projects/{project_key}/repos"):
-            yield repo
-    except Exception as e:
-        raise Exception(f"Failed to fetch repos for project '{project_key}': {e}")
+            next_start = data.get("nextPageStart")
+            start = next_start if next_start is not None else start + len(items)
 
-def fetch_commits(client: BitbucketServerClient, project_key: str, repo_slug: str, since_timestamp_ms: int) -> Generator[Dict, None, None]:
-    """Yields commits for a repository since a timestamp (ms)."""
-    # Bitbucket Server commits API doesn't strictly support 'since' date filtering in the base endpoint easily
-    # without iterating. However, we can iterate until we hit a commit older than the date.
-    # Commits are returned in reverse chronological order by default.
-    
-    endpoint = f"/rest/api/1.0/projects/{project_key}/repos/{repo_slug}/commits"
-    
+
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+def fetch_repos(client: BitbucketServerClient,
+                project_key: str) -> List[Dict[str, Any]]:
+    repos: List[Dict[str, Any]] = []
+    endpoint = f"/rest/api/1.0/projects/{project_key}/repos"
+    for repo in client.get_paginated(endpoint):
+        repos.append(repo)
+    return repos
+
+
+def _fetch_commits(
+    client: BitbucketServerClient,
+    project_key: str,
+    repo_slug: str,
+    since_timestamp_ms: int,
+) -> Generator[Dict[str, Any], None, None]:
+    """Yield commits newer than *since_timestamp_ms*.
+
+    Bitbucket Server returns commits in reverse-chronological order.
+    We stop iterating as soon as we see a commit older than our window.
+    """
+    endpoint = (
+        f"/rest/api/1.0/projects/{project_key}/repos/{repo_slug}/commits"
+    )
+    start = 0
+
     try:
-        # We need to manually handle pagination here to stop early
-        start = 0
-        limit = 100
-        
         while True:
-            params = {'start': start, 'limit': limit}
-            response = client._request('GET', endpoint, params=params)
-            data = response.json()
-            
-            items = data.get('values', [])
+            params = {"start": start, "limit": PAGE_LIMIT}
+            resp = client._get(endpoint, params=params)
+            data = resp.json()
+
+            items = data.get("values", [])
             if not items:
                 break
-                
+
             for commit in items:
-                commit_ts = commit.get('authorTimestamp', 0)
-                if commit_ts < since_timestamp_ms:
-                    return # Stop iterating, we reached older commits
+                if commit.get("authorTimestamp", 0) < since_timestamp_ms:
+                    return  # older than window
                 yield commit
-            
-            if data.get('isLastPage', True):
+
+            if data.get("isLastPage", True):
                 break
-            
-            next_start = data.get('nextPageStart')
-            if next_start:
-                start = next_start
-            else:
-                start += len(items)
-                
-    except Exception as e:
-        click.echo(f"Warning: Failed to fetch commits for repo {repo_slug}: {e}", err=True)
+
+            next_start = data.get("nextPageStart")
+            start = (
+                next_start if next_start is not None else start + len(items)
+            )
+
+    except ApiError as exc:
+        click.echo(
+            f"  Warning: commits skipped for {repo_slug} ({exc})",
+            err=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 @click.command()
-@click.option('--project', '-p', required=True, help='Bitbucket Project Key.')
-@click.option('--url', required=True, help='Bitbucket Server Base URL (e.g. https://bitbucket.mycompany.com).')
-@click.option('--user', '-u', help='Username. Overrides BITBUCKET_USER env var.')
-@click.option('--password', '-pw', help='Password/Token. Overrides BITBUCKET_PASSWORD env var.')
-@click.option('--format', 'output_format', type=click.Choice(['text', 'json']), default='text', help='Output format.')
-@click.option('--list-contributors', is_flag=True, help='List individual contributors and their emails.')
-def main(project, url, user, password, output_format, list_contributors):
-    """
-    Calculate unique contributors for a Bitbucket Server Project over the last 90 days.
-    """
+@click.option("--project", "-p", required=True,
+              help="Bitbucket Project Key.")
+@click.option("--url", required=True,
+              help="Bitbucket Server base URL.")
+@click.option("--user", "-u",
+              help="Username (overrides BITBUCKET_USER env var).")
+@click.option("--password", "-pw",
+              help="Password/Token (overrides BITBUCKET_PASSWORD env var).")
+@click.option("--format", "output_format",
+              type=click.Choice(["text", "json"]), default="text",
+              help="Output format.")
+@click.option("--list-contributors", is_flag=True,
+              help="Include per-contributor detail in output.")
+def main(
+    project: str,
+    url: str,
+    user: Optional[str],
+    password: Optional[str],
+    output_format: str,
+    list_contributors: bool,
+) -> None:
+    """Count unique contributors for a Bitbucket Server Project over the last 90 days."""
+    t0 = time.monotonic()
+
     if not user:
         user = os.environ.get(ENV_VAR_USER)
     if not password:
         password = os.environ.get(ENV_VAR_PASSWORD)
 
     if not user or not password:
-        click.echo("Error: BITBUCKET_USER and BITBUCKET_PASSWORD are required.", err=True)
+        click.echo(
+            "Error: BITBUCKET_USER and BITBUCKET_PASSWORD are required.",
+            err=True,
+        )
         sys.exit(1)
 
     client = BitbucketServerClient(url, user, password)
 
-    # Calculate window (90 days)
     now = datetime.datetime.now(datetime.timezone.utc)
-    days = 90
-    start_date = now - datetime.timedelta(days=days)
-    
-    # Bitbucket Server uses milliseconds timestamp
-    since_timestamp_ms = int(start_date.timestamp() * 1000)
+    since_timestamp_ms = int(
+        (now - datetime.timedelta(days=90)).timestamp() * 1000
+    )
 
-    contributors_map: Dict[str, Set[str]] = {}
-    repo_count = 0
-    
-    if output_format == 'text':
-        click.echo(f"Fetching repositories for {project}...")
+    # -- Fetch repos ---------------------------------------------------------
+    if output_format == "text":
+        click.echo(f"Fetching repositories for project {project} ...")
 
     try:
         repos = fetch_repos(client, project)
-        
-        for repo in repos:
-            repo_count += 1
-            repo_name = repo['name']
-            repo_slug = repo['slug']
-            
-            if output_format == 'text':
-                click.echo(f"Scanning {repo_name}...", nl=False)
-                sys.stdout.flush()
-
-            commits = fetch_commits(client, project, repo_slug, since_timestamp_ms)
-            
-            commit_count = 0
-            for commit in commits:
-                commit_count += 1
-                author = commit.get('author', {})
-                email = author.get('emailAddress')
-                name = author.get('name')
-                
-                # Use email as unique identifier
-                identifier = email if email else name
-                
-                if identifier:
-                    if identifier not in contributors_map:
-                        contributors_map[identifier] = set()
-                    if email:
-                        contributors_map[identifier].add(email)
-            
-            if output_format == 'text':
-                click.echo(f" Done. ({commit_count} commits)")
-
-    except Exception as e:
-        click.echo(f"\nError: {e}", err=True)
+    except ApiError as exc:
+        click.echo(f"Error: {exc}", err=True)
         sys.exit(1)
 
+    total_repos = len(repos)
+    if output_format == "text":
+        click.echo(f"  Found {total_repos} repositories.\n")
+
+    # -- Scan repos ----------------------------------------------------------
+    contributors_map: Dict[str, Set[str]] = {}
+    total_commits = 0
+
+    for idx, repo in enumerate(repos, 1):
+        repo_name: str = repo["name"]
+        repo_slug: str = repo["slug"]
+
+        if output_format == "text":
+            pad = len(str(total_repos))
+            click.echo(
+                f"  [{idx:>{pad}}/{total_repos}] {repo_name} ...",
+                nl=False,
+            )
+            sys.stdout.flush()
+
+        commit_count = 0
+        for commit in _fetch_commits(
+            client, project, repo_slug, since_timestamp_ms,
+        ):
+            commit_count += 1
+            author = commit.get("author", {})
+            email: Optional[str] = author.get("emailAddress")
+            name: Optional[str] = author.get("name")
+
+            identifier = email if email else name
+            if identifier:
+                if identifier not in contributors_map:
+                    contributors_map[identifier] = set()
+                if email:
+                    contributors_map[identifier].add(email)
+
+        total_commits += commit_count
+        if output_format == "text":
+            click.echo(f" {commit_count:,} commits")
+
+    elapsed = time.monotonic() - t0
     total_contributors = len(contributors_map)
 
-    if output_format == 'json':
-        json_output = {
+    # -- Output --------------------------------------------------------------
+    if output_format == "json":
+        payload: Dict[str, Any] = {
             "project": project,
-            "scan_date": now.strftime('%Y-%m-%d'),
-            "contributors_90d": total_contributors
+            "server_url": url,
+            "scan_date": now.strftime("%Y-%m-%d"),
+            "repositories_scanned": total_repos,
+            "elapsed_seconds": round(elapsed, 1),
+            "contributors_90d": total_contributors,
         }
-        
         if list_contributors:
-            json_output["contributors_details"] = [
-                {"identifier": ident, "emails": sorted(list(emails))}
+            payload["contributors_details"] = [
+                {"identifier": ident, "emails": sorted(emails)}
                 for ident, emails in sorted(contributors_map.items())
             ]
-            
-        click.echo(json.dumps(json_output, indent=2))
+        click.echo(json.dumps(payload, indent=2))
     else:
-        click.echo("\n" + "="*40)
-        click.echo(f"Project: {project}")
-        click.echo(f"Scan Date: {now.strftime('%Y-%m-%d')}")
-        click.echo(f"Repositories scanned: {repo_count}")
-        click.echo("-" * 40)
-        click.echo(f"Contributors in last 90 days: {total_contributors}")
-        
-        if list_contributors:
-            click.echo("-" * 40)
-            click.echo("Contributors:")
-            for ident in sorted(contributors_map.keys()):
-                emails = ", ".join(sorted(contributors_map[ident]))
-                click.echo(f"  - {ident} ({emails})")
-                
-        click.echo("="*40)
+        rows: List[Tuple[str, str]] = [
+            ("Project:", project),
+            ("Server:", url),
+            ("Scan Date:", now.strftime("%Y-%m-%d")),
+            ("Repositories Scanned:", str(total_repos)),
+            ("Total Commits:", f"{total_commits:,}"),
+            ("Elapsed:", _elapsed(elapsed)),
+        ]
+        _summary_box(
+            "Bitbucket Server Contributors - 90 Day",
+            rows,
+            "Unique Contributors:", str(total_contributors),
+        )
 
-if __name__ == '__main__':
+        if list_contributors:
+            click.echo("\n  Contributors:")
+            for ident in sorted(contributors_map):
+                emails_str = (
+                    ", ".join(sorted(contributors_map[ident])) or "N/A"
+                )
+                click.echo(f"    {ident:<30} {emails_str}")
+            click.echo()
+
+
+if __name__ == "__main__":
     main()

--- a/bitbucket/requirements.txt
+++ b/bitbucket/requirements.txt
@@ -1,2 +1,2 @@
-requests
-click
+requests>=2.28.0
+click>=8.0


### PR DESCRIPTION
## Summary of Changes

### 1. API Efficiency & Reliability (all scripts)

| Change | Rationale |
|--------|-----------|
| **`HTTPAdapter` with `urllib3.Retry`** — 3 retries, exponential backoff (1s → 2s → 4s), for 500/502/503/504 | Transient server errors are common on enterprise self-hosted instances. The retry adapter handles this transparently at the transport layer. |
| **Connection pooling** — `pool_connections=10, pool_maxsize=10` | Keeps TCP connections alive across paginated calls, avoiding repeated TLS handshakes. |
| **Request timeouts** — `(10, 30)` (connect, read) | Prevents hung connections from blocking the scan forever. A 10s connect timeout catches DNS/firewall issues fast; 30s read timeout is generous enough for slow APIs. |
| **`ThreadPoolExecutor` (GitHub only)** — 4 concurrent workers scanning repos in parallel | GitHub's all-branches mode generates N×M API calls (repos × branches). Threading cuts wall-clock time by ~4x on large orgs. Thread-safe via `threading.local()` sessions with per-thread connection pools. |
| **GitLab `retry_transient_errors=True`** | The `python-gitlab` library has native retry support — used it instead of wrapping manually. |

### 2. Cleanliness & CLI UX (all scripts)

| Change | Rationale |
|--------|-----------|
| **`[1/47]` progress counters** | Shows clear progress during long scans. Padding is dynamic based on total repo count. |
| **Eager repo fetching** | Repos are loaded into a list upfront so we can display `Found 47 repositories.` before scanning begins. Essential for setting expectations during demos. |
| **Consistent `_summary_box()` output** | Every script prints an identical box-formatted summary. Renders cleanly in PowerShell, bash, and zsh — no unicode box-drawing characters that might break on Windows. |
| **Elapsed time** | Shown in both text and JSON output. Uses `time.monotonic()` for accuracy. |
| **Comma-formatted commit counts** | `f"{cc:,}"` — reads as `5,318 commits` instead of `5318`. |
| **Structured JSON output** | Added `repositories_scanned`, `elapsed_seconds`, `projects_scanned` fields to every platform's JSON output. |

### 3. Maintainability & Robustness (all scripts)

| Change | Rationale |
|--------|-----------|
| **`ApiError` exception class** | Replaces bare `Exception`. Carries the HTTP status code and a sanitized message. |
| **Eliminated all bare `except:` clauses** | Replaced with specific `except (ValueError, KeyError):` or `except ApiError:`. Bare excepts swallow `KeyboardInterrupt` and `SystemExit`. |
| **Full type hints** | Every function signature, return type, and important local variable is annotated. |
| **GitLab `getattr()` safety** | Commit attributes accessed via `getattr(commit, "author_email", None)` instead of direct attribute access, preventing `AttributeError` on malformed responses. |
| **Graceful per-repo failures** | If one repo's commits can't be fetched (empty repo, permission denied, archived), the scan logs a warning and continues to the next repo instead of crashing. |
| **`__repr__` on all client classes** | Safe representations that show authentication state without leaking the token. |

### 4. Security (all scripts)

| Change | Rationale |
|--------|-----------|
| **`_sanitize()` on all error messages** | Truncates to 300 chars and strips embedded credentials from URLs (replaces `://user:pass@` with `://***@`). Prevents accidental token exposure in tracebacks. |
| **Thread-local sessions (GitHub)** | Each thread gets its own `requests.Session` via `threading.local()`. Auth headers are set per-session and never shared across thread boundaries. |
| **No token in `__repr__`** | Client objects show `authenticated=True/False`, never the actual token. |
| **`.env` in `.gitignore`** | Prevents accidental commit of `.env` files containing PATs. |
| **Minimum dependency versions** | `requests>=2.28.0` and `click>=8.0` ensure compatibility with the `Retry(allowed_methods=...)` parameter and modern click features. |
